### PR TITLE
增加微信小程序toast增强插件

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,4 @@
 - [微信小程序倒计时组件(微信公众号)](http://mp.weixin.qq.com/s?__biz=MzI0MjYwMjM2NQ==&mid=2247483670&idx=1&sn=5aa5da2fff2415e9b19f848712ddf480&chksm=e9789904de0f1012159332fda391c3eec0bb3d1c0db2c34ab557208ff0c04806a40d00e844fe&mpshare=1&scene=1&srcid=1007cWRXdd0ug9oAceCsIWp6#rd)
 - [微信小程序下拉筛选组件(微信公众号)](http://mp.weixin.qq.com/s?__biz=MzI0MjYwMjM2NQ==&mid=2247483674&idx=1&sn=2bf242b391144f3f0e57e0ed0ebce36f&chksm=e9789908de0f101ee23f7c125c9a48c4f9ba3f242a3b1c89b05ca5b9e8e68262c02b47fe3d12&mpshare=1&scene=1&srcid=1008NvO9oI8wWGp4XBxlpLeL#rd)
 - [w3c 标准 API polyfill](https://github.com/leancloud/weapp-polyfill)
+- [WeToast——微信小程序toast增强插件](https://github.com/kiinlam/wetoast)


### PR DESCRIPTION
WeToast 是仿照微信小程序提供的 showToast 功能，提供视觉一致的增强插件，弥补小程序showToast功能上的不足（如只能显示success、loading两种icon，且icon不可去除，持续时间最大10秒等）。