### PR TITLE
add wech

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 - [wxml-parser JavaScript WXML parser](https://github.com/seanlong/wxml-parser) 以及[在线页面demo](https://seanlong.github.io/wxapp-page-editor)
 - [Px转Rpx在线工具](http://allanguys.github.io/px2rpx)
 - [微信小程序云端增强 SDK XpmJS ](https://github.com/xpmjs/xpmjs)
+- [4kb模块化开发工具 将模块化的属性和方法映射成小程序页面](https://github.com/chenzhuo1992/wech)
 
 ## 插件
 


### PR DESCRIPTION
极轻量（4kb）的微信小程序模块化组件开发helper，没有任何构建相关的骨架或者约束。在运行阶段自动通过getter/setter，将你的“模块化组件”的数据和方法的映射到小程序的实际页面。支持组件嵌套、防止方法名污染。